### PR TITLE
#190  AK_check_constraint_name improved

### DIFF
--- a/akdb/src/sql/cs/between.c
+++ b/akdb/src/sql/cs/between.c
@@ -107,7 +107,7 @@ void AK_set_constraint_between(char* tableName, char* constraintName, char* attN
         }
     }*/
 
-    if (AK_check_constraint_name(constraintName) == EXIT_ERROR) {
+    if (AK_check_constraint_name(constraintName, AK_CONSTRAINTS_BEWTEEN) == EXIT_ERROR) {
         printf("\n*** ERROR ***\nFailed to add 'between constraint' on TABLE: %s\nConstrait '%s' already exists in the database!\n\n", tableName, constraintName);
 
         AK_EPI;
@@ -304,7 +304,7 @@ int AK_delete_constraint_between(char* tableName, char* constraintNamePar){
 
     char* constraint_attr = "constraintName";
 
-    if(AK_check_constraint_name(constraintNamePar) == EXIT_SUCCESS){
+    if(AK_check_constraint_name(constraintNamePar, AK_CONSTRAINTS_BEWTEEN) == EXIT_SUCCESS){
         printf("FAILURE! -- CONSTRAINT with name %s doesn't exist in TABLE %s", constraintNamePar, tableName);
         AK_EPI;
         return EXIT_ERROR;

--- a/akdb/src/sql/cs/check_constraint.c
+++ b/akdb/src/sql/cs/check_constraint.c
@@ -167,7 +167,7 @@ int AK_set_check_constraint(char *table_name, char *constraint_name, char *attri
         }
     }
 
-    if (AK_check_constraint_name(constraint_name) == EXIT_ERROR) {
+    if (AK_check_constraint_name(constraint_name, AK_CONSTRAINTS_CHECK_CONSTRAINT) == EXIT_ERROR) {
         printf("\n*** ERROR ***\nFailed to add 'check constraint' on TABLE: %s\nConstrait '%s' already exists in the database!\n\n", table_name, constraint_name);
 
         AK_EPI;
@@ -281,7 +281,7 @@ int AK_delete_check_constraint(char* tableName, char* constraintName){
 
     char* constraint_attr = "constraint_name";
 
-    if(AK_check_constraint_name(constraintName) == EXIT_SUCCESS){
+    if(AK_check_constraint_name(constraintName, AK_CONSTRAINTS_CHECK_CONSTRAINT) == EXIT_SUCCESS){
         printf("FAILURE! -- CONSTRAINT with name %s doesn't exist in TABLE %s", constraintName, tableName);
         AK_EPI;
         return EXIT_ERROR;

--- a/akdb/src/sql/cs/constraint_names.c
+++ b/akdb/src/sql/cs/constraint_names.c
@@ -120,7 +120,7 @@ TestResult AK_constraint_names_test() {
 	printf("Yes (0) No (-1): %d\n\n", result);
 
 
-	printf("\nSetting year to unique in table student\n");
+	printf("\nSetting year attribute to UNIQUE in table student\n");
 	AK_set_constraint_unique(tableName,  attYear, constraintYear);
 	printf("\nChecking if constraint name %s would be unique in database...\n", constraintYear);
 	result = AK_check_constraint_name(constraintYear, AK_CONSTRAINTS_UNIQUE);
@@ -132,7 +132,7 @@ TestResult AK_constraint_names_test() {
 		printf("\nFAILED\n\n");
 	}
 
-	printf("\nDeleting constraint year unique in table student\n");
+	printf("\nDeleting the UNIQUE constraint on atribute year in table student\n");
 	AK_delete_constraint_unique("AK_constraints_unique", constraintYear);
 	result = AK_check_constraint_name(constraintYear, AK_CONSTRAINTS_UNIQUE);
 	if(result==EXIT_SUCCESS){

--- a/akdb/src/sql/cs/constraint_names.c
+++ b/akdb/src/sql/cs/constraint_names.c
@@ -21,9 +21,10 @@
 #include "constraint_names.h"
 
 /**
- * @author Nenad Makar, updated by Matej Lipovača
+ * @author Nenad Makar, updated by Matej Lipovača, updated by Marko Belusic
  * @brief Function that checks if constraint name would be unique in database 
- * @param char constraintName name which you want to give to constraint which you are trying to create
+ * @param constraintName constraintName name which you want to give to constraint which you are trying to create
+ * @param constraintTable name of the constraint table you want to seach, put NULL if you want to seach all constraint tables
  * @return EXIT_ERROR or EXIT_SUCCESS
  **/
 int AK_check_constraint_name(char *constraintName, char *constraintTable) {

--- a/akdb/src/sql/cs/constraint_names.h
+++ b/akdb/src/sql/cs/constraint_names.h
@@ -31,7 +31,7 @@
  * @param char constraintName name which you want to give to constraint which you are trying to create
  * @return EXIT_ERROR or EXIT_SUCCESS
  **/
-int AK_check_constraint_name(char *constraintName);
+int AK_check_constraint_name(char *constraintName, char *constraintTable);
 TestResult AK_constraint_names_test();
 
 #endif

--- a/akdb/src/sql/cs/nnull.c
+++ b/akdb/src/sql/cs/nnull.c
@@ -121,7 +121,7 @@ int AK_check_constraint_not_null(char* tableName, char* attName, char* constrain
 		}
 	}
 
-	uniqueConstraintName = AK_check_constraint_name(constraintName);
+	uniqueConstraintName = AK_check_constraint_name(constraintName, AK_CONSTRAINTS_NOT_NULL);
 
 	if(uniqueConstraintName == EXIT_ERROR)
 	{
@@ -196,7 +196,7 @@ int AK_delete_constraint_not_null(char* tableName, char* constraintName){
 
     char* constraint_attr = "constraintName";
 
-    if(AK_check_constraint_name(constraintName) == EXIT_SUCCESS){
+    if(AK_check_constraint_name(constraintName, AK_CONSTRAINTS_NOT_NULL) == EXIT_SUCCESS){
         printf("FAILURE! -- CONSTRAINT with name %s doesn't exist in TABLE %s", constraintName, tableName);
         AK_EPI;
         return EXIT_ERROR;

--- a/akdb/src/sql/cs/unique.c
+++ b/akdb/src/sql/cs/unique.c
@@ -140,7 +140,7 @@ int AK_set_constraint_unique(char* tableName, char attName[], char constraintNam
 
 	
 
-	uniqueConstraintName = AK_check_constraint_name(constraintName);
+	uniqueConstraintName = AK_check_constraint_name(constraintName, AK_CONSTRAINTS_UNIQUE);
 
 	if(uniqueConstraintName == EXIT_ERROR)
 	{
@@ -421,7 +421,7 @@ int AK_delete_constraint_unique(char* tableName, char* constraintName){
 
     char* constraint_attr = "constraintName";
 
-    if(AK_check_constraint_name(constraintName) == EXIT_SUCCESS){
+    if(AK_check_constraint_name(constraintName, AK_CONSTRAINTS_UNIQUE) == EXIT_SUCCESS){
         printf("FAILURE! -- CONSTRAINT with name %s doesn't exist in TABLE %s", constraintName, tableName);
         AK_EPI;
         return EXIT_ERROR;

--- a/akdb/src/sql/select.c
+++ b/akdb/src/sql/select.c
@@ -232,7 +232,6 @@ TestResult AK_select_test(){
     // reset all the tables
     AK_delete_segment(destTable1, SEGMENT_TYPE_TABLE);
     AK_delete_segment(destTable2, SEGMENT_TYPE_TABLE);
-    AK_delete_segment(srcTable, SEGMENT_TYPE_TABLE);
 	AK_EPI;
 
 	return TEST_result(succesfulTests, failedTests);

--- a/akdb/src/swig/kalashnikovDB.i
+++ b/akdb/src/swig/kalashnikovDB.i
@@ -418,4 +418,4 @@ extern AK_header *AK_get_insert_header(int *size, char *tblName, struct list_nod
 extern int AK_insert(char* tableName, struct list_node *columns, struct list_node *values);
 
 
-extern int AK_check_constraint_name(char *constraintName);
+extern int AK_check_constraint_name(char *constraintName, char *constraintTable);


### PR DESCRIPTION
 AK_check_constraint_name now accepts additional parameter.
All functions that were using  AK_check_constraint_name are updated and tested.

Also, test 50(constraint_names.c) is improved. It was not following guidelines for testing and it was hardcoded SUCCESS, now that is fixed.