### PR TITLE
izmjena u datoteci nat_join.c

### DIFF
--- a/akdb/src/rel/nat_join.c
+++ b/akdb/src/rel/nat_join.c
@@ -380,18 +380,18 @@ TestResult AK_op_join_test() {
     char *srcTable2 = "table2";
     char *dstTable = "join_table";
     
-    AK_header header1[MAX_ATTRIBUTES];
+    AK_header header1[MAX_ATTRIBUTES] = {0}; // dodano inicijaliziranje na 0
     strcpy(header1[0].att_name, "id");
-    strcpy(header1[0].type, "int");
+    header1[0].type = TYPE_INT; // dodano inicijaliziranje na TYPE_INT
     strcpy(header1[1].att_name, "name");
-    strcpy(header1[1].type, "varchar(255)");
+    header1[1].type = TYPE_VARCHAR; // dodano inicijaliziranje na TYPE_VARCHAR
     
-    AK_header header2[MAX_ATTRIBUTES];
+    AK_header header2[MAX_ATTRIBUTES] = {0}; // dodano inicijaliziranje na 0
     
     strcpy(header2[0].att_name, "id");
-    strcpy(header2[0].type, "int");
+    header2[0].type = TYPE_INT; // dodano inicijaliziranje na TYPE_INT
     strcpy(header2[1].att_name, "age");
-    strcpy(header2[1].type, "int");
+    header2[1].type = TYPE_INT; // dodano inicijaliziranje na TYPE_INT
     
     AK_temp_create_table(srcTable1, header1, SEGMENT_TYPE_TABLE);
     AK_temp_create_table(srcTable2, header2, SEGMENT_TYPE_TABLE);


### PR DESCRIPTION
Test 30 (AK_op_join) se zbog pogrešno dodijeljenih vrijednosti u zaglavlje header1 i header2 rušio. Valgrind je pokazao kako se radi o grešci u 385 liniji koda. Umjesto stvarne vrste (tipa) vrijednosti (int i varchar) dodjeljivao se tekst "int" i "varchar(255)". U dokumentu refman.pdf na 114 stranici prikazane vrste tipova podataka. Umjesto stringova, u zaglavlju se dodijelilo TYPE_INT (u constants.h određeno vrijednošću 1) i TYPE_VARCHAR (u constants.h određeno vrijednošću 4). Nakon toga test uspješno prolazi taj dio.