### PR TITLE
Fix/Issue #150 - drop.c

### DIFF
--- a/akdb/src/sql/drop.c
+++ b/akdb/src/sql/drop.c
@@ -591,7 +591,7 @@ TestResult AK_drop_test() {
     AK_print_table("AK_function_arguments");
 
     printf("\n-----DROP USER-----\n");
-    AK_user_add("user_drop_test",1234,1);
+    AK_user_add("user_drop_test","1234",1);
     drop_arguments->value = "user_drop_test";
     drop_arguments->next = (AK_drop_arguments *)AK_malloc(sizeof (AK_drop_arguments));
     drop_arguments->next->value = "CASCADE";

--- a/akdb/src/sql/drop.c
+++ b/akdb/src/sql/drop.c
@@ -512,6 +512,16 @@ TestResult AK_drop_test() {
     drop_arguments->next->value = NULL;
     drop_arguments->next->next->value = NULL;
 
+    
+AK_create_table_parameter parameters[2];
+
+strcpy(parameters[0].name, "id_department");
+parameters[0].type = TYPE_INT;
+
+strcpy(parameters[1].name, "manager");
+parameters[1].type = TYPE_VARCHAR;
+
+AK_create_table("department", parameters, 2);
 
     printf("\n-----DROP TABLE-----\n");
     AK_print_table("AK_relation");


### PR DESCRIPTION
Popravljen drop.c
- Uklonjeni dupli testovi (npr. dvostruki DROP GROUP)
- Uklonjen problem s alokacijom memorije
- omogućeno izvršavanje testova do kraja
- komentirane glavne funkcije kako bi kod bio pregledniji
- dodano kreiranje tablice prije DROP TABLE kako bi test vratio EXIT_SUCCESS