### PR TITLE
Implementacija drop table naredbe

### DIFF
--- a/akdb/src/srv/modules/data_manipulation_module.py
+++ b/akdb/src/srv/modules/data_manipulation_module.py
@@ -382,7 +382,7 @@ class Update_command:
 
 
 # Drop
-#@author Filip Sostarec
+#@author Filip Sostarec, updated by Laura Krišković
 class Drop_command:
 
     drop_regex = r"^(?i)drop(\s([a-zA-Z0-9_\(\),'\.]+))+?$"
@@ -411,25 +411,29 @@ class Drop_command:
         else:
             return None
 
-    def execute(self):
+    def execute(self, expression):
+        self.expr = expression
         parser = sql_tokenizer()
         token = parser.AK_parse_drop(self.expr)
         print(f"{token=}")
+    
         if isinstance(token, str):
             print("Error: syntax error in expression")
             print(token)
             return False
+
         objekt = str(token.objekt)
-        # Removes all []' from string
         translation_table = str.maketrans("", "", "[]'")
-        table_name = str(token.ime_objekta)
-        table_name = table_name.translate(translation_table)
+        table_name = str(token.ime_objekta).translate(translation_table)
 
         drop_args = AK47.drop_arguments()
         drop_args.value = table_name
 
-        if (AK47.AK_table_exist(table_name) == 0):
-            print("Error: table '" + table_name + "' does not exist")
+        if AK47.AK_table_exist(table_name) == 0:
+            print(f"Error: table '{table_name}' does not exist")
             return False
-        
+
         AK47.AK_drop(self._dropType[objekt], drop_args)
+        return True
+
+

--- a/akdb/src/srv/sql_executor.py
+++ b/akdb/src/srv/sql_executor.py
@@ -49,16 +49,21 @@ class Sql_executor:
     # and call its execution if it matches
     def commands_for_input(self, command):
         if isinstance(command, str) and len(command) > 0:
+            drop_cmd = Drop_command()
+            if drop_cmd.matches(command):
+                return ("DropCommand", drop_cmd.execute(command))
+
             for elem in self.commands:
                 if elem.matches(command) is not None:
                     print(elem)
                     return (elem.__class__.__name__, elem.execute(command))
         return ("",  "Error. Wrong command: " + command)
 
+
     # execute method
     # called when a new command is received (from client)
     def execute(self, command):
-    # Provjera za "\t <ime_tabele>?" komandu
+    # execute "\t <ime_tabele>?" command
         if isinstance(command, str) and command.startswith("\\t ") and command.endswith("?"):
             tablename = command[3:-1].strip()
             exists = AK47.AK_table_exist(tablename)
@@ -66,10 +71,8 @@ class Sql_executor:
                 return ("TableExistsCommand", f"✔ Table '{tablename}' exists.")
             else:
                 return ("TableExistsCommand", f"✖ Table '{tablename}' does NOT exist.")
-
-    # Sve ostale naredbe idu normalno
+    
         return self.commands_for_input(command)
-
 
 
     # insert
@@ -160,3 +163,33 @@ class Sql_executor:
             return True
         else:
             return False
+
+    def drop(self, expr):
+        parser = sql_tokenizer()
+        token = parser.AK_parse_drop(expr)
+
+        if isinstance(token, str):
+            print("Error: syntax error in expression")
+            return False
+
+        objekt = token.objekt.lower()
+        ime_objekta = token.ime_objekta.replace("'", "").replace("`", "").strip()
+
+        _dropType = {
+            "table": AK47.OBJECT_TYPE_TABLE,
+            "index": AK47.OBJECT_TYPE_INDEX,
+            "sequence": AK47.OBJECT_TYPE_SEQUENCE,
+            "trigger": AK47.OBJECT_TYPE_TRIGGER,
+            "view": AK47.OBJECT_TYPE_VIEW
+        }
+
+        if objekt not in _dropType:
+            print(f"Error: unknown object type '{objekt}'")
+            return False
+
+        if AK47.AK_drop(_dropType[objekt], ime_objekta) == AK47.EXIT_SUCCESS:
+            return True
+        else:
+            print(f"Error: failed to drop {objekt} '{ime_objekta}'")
+            return False
+

--- a/akdb/src/srv/sql_executor.py
+++ b/akdb/src/srv/sql_executor.py
@@ -58,9 +58,19 @@ class Sql_executor:
     # execute method
     # called when a new command is received (from client)
     def execute(self, command):
-        #tmp = self.commands_for_input(command)
-        #print(f"{tmp=}")
+    # Provjera za "\t <ime_tabele>?" komandu
+        if isinstance(command, str) and command.startswith("\\t ") and command.endswith("?"):
+            tablename = command[3:-1].strip()
+            exists = AK47.AK_table_exist(tablename)
+            if exists:
+                return ("TableExistsCommand", f"✔ Table '{tablename}' exists.")
+            else:
+                return ("TableExistsCommand", f"✖ Table '{tablename}' does NOT exist.")
+
+    # Sve ostale naredbe idu normalno
         return self.commands_for_input(command)
+
+
 
     # insert
     # executes the insert expression


### PR DESCRIPTION
Implementirana je drop table naredba (ostale drop naredbe ne daju se testirati jer ni create ne funkcionira), ali testiranjem funkcionalnosti popravljenog koda server bi ušao u beskonačnu petlju uzrokovanu SIGSEGV greškom, a za uzrok greške naveden je AK_get_tuple. 

Po mojem shvaćanju greške, u funkciji AK_if_exist broj redaka tablice se dobiva pozivom AK_get_num_records(sys_table), koji određuje koliko puta će se izvršiti petlja kroz redove. Za svaki red dohvaća se tuple pomoću AK_get_tuple(rowIndex, 1, sys_table) i provjerava postoji li traženi naziv tablice (tblName). Mislim da problem nastaje jer AK_get_num_records vraća netočan broj redaka: on broji sve tupleove sa veličinom >0 u svim blokovima pa rezultat dijeli s brojem atributa, što ne funkcionira ispravno kada tablica ima više atributa nego što je definirano u MAX_ATTRIBUTES. Zato nastaje beskonačna petlja. Trebalo bi kreirati novi issue za debug ovog problema. Međutim, naredba drop table trebala bi nakon toga funkcionirati.